### PR TITLE
1.0.1

### DIFF
--- a/architecture-and-data-models/oasc-mim-2-data-models.md
+++ b/architecture-and-data-models/oasc-mim-2-data-models.md
@@ -67,6 +67,7 @@ Harmonization across data models help in supporting different data models again 
 * SAREF: Smart Appliances REFerence \(SAREF\) ontology specified by ETSI OneM2M committee with the extension of SAREF4Cities provides an ontology focused on smart cities
 * Core vocabularies of ISA like Core Public Service Vocabulary Application Profile used as the basis for the Single Digital Gateway Regulation that touches local governments, Core Person, Core Organization etc
 * DTDL is the Digital twin Definition Language developed by Microsoft. This language is based on top op json-ld and the existing Fiware data models are converted in this format.
+* For spatial (and spatio-tempopral) observation data the provisions of [MIM-7 (Places)](../interaction/oasc-mim7-places.md) about data encoding have to be taken into consideration.
 
 {% hint style="info" %}
 Unfinished page

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -92,7 +92,7 @@ This section specifies data encodings for geospatial data that is also relevant 
 
 ### Standards for implementing European Union's INSPIRE Directive
 
-For the European Union context, non-binding [technical guidelines](https://inspire.ec.europa.eu/Technical-Guidelines/Data-Specifications/2892) and [good practices](https://inspire.ec.europa.eu/portfolio/good-practice-library) are available for implementing the legal provisions of the [INSPIRE Directive](https://inspire.ec.europa.eu). Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The governance of the technical specifications is ensured by the INSPIRE Maintenance and Implementation group (MIG), and its permanent technical sub-group (MIG-T). The following standards are available:
+For the European Union context, non-binding [technical guidelines](https://inspire.ec.europa.eu/Technical-Guidelines) and [good practices](https://inspire.ec.europa.eu/portfolio/good-practice-library) are available for implementing the legal provisions of the [INSPIRE Directive](https://inspire.ec.europa.eu). Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The governance of the technical specifications is ensured by the INSPIRE Maintenance and Implementation group (MIG), and its permanent technical sub-group (MIG-T). The following standards are available:
 
 #### Network services
   * Discovery Services \(OGC CSW\)
@@ -100,11 +100,14 @@ For the European Union context, non-binding [technical guidelines](https://inspi
   * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds, [SensorThings API](https://github.com/INSPIRE-MIF/gp-ogc-sensorthings-api), [OGC API - Features](https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md)\)
 
 #### Data encoding
+The [INSPIRE data specifications](https://inspire.ec.europa.eu/Technical-Guidelines) define common data models, code lists, map layers and additional metadata on the interoperability to be used when exchanging spatial datasets. In addition, a dedicated [Location Core Vocabulary](https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/core-location-vocabulary/release/100) provides a minimum set of classes and properties for describing a location represented as an address, a geographic name, or a geometry.
+
   * [GML](https://github.com/INSPIRE-MIF/application-schemas)
   * [GeoJSON](https://github.com/INSPIRE-MIF/2017.2/blob/master/GeoJSON/geojson-encoding-rule.md)
   * [GeoPackage](https://github.com/INSPIRE-MIF/gp-geopackage-encodings)
 
+
 #### Validation
 
-An advantage of INSPIRE is the ability to validate metadata, services and data aginst the technical provisions listed above. To this end, the [INSPIRE reference validator](https://inspire.ec.europa.eu/validator/), fully based on open source components, is being used.
+An advantage of INSPIRE is the ability to validate metadata, services and data against the technical provisions listed above. To this end, the [INSPIRE reference validator](https://inspire.ec.europa.eu/validator/), fully based on open source components, is being used. Local instances of the tool can be deployed within the cities own infrastructures in addition to the centrally available solution.
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -45,9 +45,7 @@ description: 'OASC MIM7: Geospatial Information Management'
 
 ## Objectives <a id="MIM1:ContextInformationManagement-Goal"></a>
 
-Specifies how to share spatial (and spatio-temporal) data, make theme interoperable with, within, and between systems and territories. This goes from static data about assets such as street lights, buildings, and streets to spatio-temporal data from sensors. The purpose of this Minimal Interoperability Mechanism (MIM) is to make this data and the way it is shared interoperable across cities, but also among stakeholders within the city. 
-
-This MIM will also provide input to [MIM2 Data models](), in particular regarding data whih has a geospatial dimension.
+Specifies how to share spatial (and spatio-temporal) data, make theme interoperable with, within, and between systems and territories. This goes from static data about assets such as street lights, buildings, and streets to spatio-temporal data from sensors. The purpose of this Minimal Interoperability Mechanism (MIM) is to make this data and the way it is shared interoperable across cities, but also among stakeholders within the city. This MIM will also provide input to [MIM2 Data models](), in particular regarding data whih has a geospatial dimension.
 
 ## Capabilities
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -77,8 +77,10 @@ The specifications that are subject to adoption are focussing on (i) web interfa
   * OGC Sensor Observation Services \([SOS](https://www.ogc.org/standards/sos)\)
 
 * **API-based family of standards:**
-  * The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards), built upon the legacy of the OGC Web Service standards, to define resource-centric APIs that take advantage of modern web development practices. These standards are web-friendly and are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(The following OGC APIs are at a different stage of development: Features, Common, Maps, Records, Processes, Coverages, Tiles, Environmental Data Retrieval\).
+
+The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards), built upon the legacy of the OGC Web Service standards, to define resource-centric APIs that take advantage of modern web development practices. These standards are web-friendly and are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(The following OGC APIs are at a different stage of development: Features, Common, Maps, Records, Processes, Coverages, Tiles, Environmental Data Retrieval\).
   * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings), provides an open-source and uniform API to connect IoT devices, data and applications on the Web, it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of OGC SOS and SPS.
+  * The [OGC API-Features](https://www.ogc.org/standards/ogcapi-features) xxxxxxxxx.
 
 \*\*\*\*
 
@@ -103,4 +105,7 @@ For the European Union context, non-binding technical approaches are endorsed by
 
 #### Data encoding
 
+#### Validation
+
+An advantage of INSPIRE is the ability to validate metadata, services and data aginst the technical provisions listed above. To this end, an open source reference validator is being used.
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -95,9 +95,10 @@ This section specifies data encodings for geospatial data that is also relevant 
 For the European Union context, non-binding [technical guidelines](https://inspire.ec.europa.eu/Technical-Guidelines) and [good practices](https://inspire.ec.europa.eu/portfolio/good-practice-library) are available for implementing the legal provisions of the [INSPIRE Directive](https://inspire.ec.europa.eu). Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The governance of the technical specifications is ensured by the INSPIRE Maintenance and Implementation group (MIG), and its permanent technical sub-group (MIG-T). The following standards are available:
 
 #### Network services
-  * Discovery Services \(OGC CSW\)
-  * View Services \(OGC WMS, WMTS\)
-  * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds, [SensorThings API](https://github.com/INSPIRE-MIF/gp-ogc-sensorthings-api), [OGC API - Features](https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md)\)
+NSPIRE Network Services specify common interfaces for web services. Dedicated technical guidelines are made available for: 
+  * Discovery Services \([OGC CSW](https://inspire.ec.europa.eu/documents/technical-guidance-implementation-inspire-discovery-services-0)\)
+  * View Services \([OGC WMS, WMTS](https://inspire.ec.europa.eu/documents/technical-guidance-implementation-inspire-view-services-1)\)
+  * Download Services \([OGC WFS](https://inspire.ec.europa.eu/documents/technical-guidance-implementation-inspire-download-services), [WCS](https://inspire.ec.europa.eu/id/document/tg/download-wcs), [SOS](https://inspire.ec.europa.eu/id/document/tg/download-sos), [ATOM Feeds](https://inspire.ec.europa.eu/documents/technical-guidance-implementation-inspire-download-services), [SensorThings API](https://github.com/INSPIRE-MIF/gp-ogc-sensorthings-api), [OGC API - Features](https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md)\)
 
 #### Data encoding
 The [INSPIRE data specifications](https://inspire.ec.europa.eu/Technical-Guidelines) define common data models, code lists, map layers and additional metadata on the interoperability to be used when exchanging spatial datasets. In addition, a dedicated [Location Core Vocabulary](https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/core-location-vocabulary/release/100) provides a minimum set of classes and properties for describing a location represented as an address, a geographic name, or a geometry.

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -34,7 +34,7 @@ description: 'OASC MIM7: Geospatial Information Management'
     <tr>
       <td style="text-align:center">&#x2705;</td>
       <td style="text-align:center"></td>
-      <td style="text-align:center">&#x2705;</td>
+      <td style="text-align:center"></td>
       <td style="text-align:center"></td>
       <td style="text-align:center"></td>
       <td style="text-align:center"></td>
@@ -74,7 +74,7 @@ Integrating context information with geospatial information can be enabled by th
 
 
 
-* **European INSPIRE Directive adopted OGC and ISO \(19115/19119/19139\) specifications:**
+* **Standards for implementing European Union's INSPIRE Directive:**
   * Discovery Services \(OGC CSW\)
   * View Services \(OGC WMS\)
   * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds\)

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -45,7 +45,7 @@ description: 'OASC MIM7: Places'
 
 ## Objectives <a id="MIM1:ContextInformationManagement-Goal"></a>
 
-Specifies how to share spatial (and spatio-temporal) data, make them interoperable with, within, and between systems and territories. This goes from static data about assets such as street lights, buildings, and streets to spatio-temporal data from sensors. The purpose of this Minimal Interoperability Mechanism (MIM) is to make this data and the way it is shared interoperable across cities, but also among stakeholders within the same city. This MIM will also provide input to [MIM2 Data models](https://github.com/alexanderkotsev/oasc-mims/blob/1.0.1/architecture-and-data-models/oasc-mim-2-data-models.md), in particular regarding data which has an explicit geospatial dimension.
+Specifies how to share spatial (and spatio-temporal) data, make them interoperable with, within, and between systems and territories. This goes from static data about assets such as street lights, buildings, and streets to spatio-temporal data from sensors. The purpose of this Minimal Interoperability Mechanism (MIM) is to make this data and the way it is shared interoperable across cities, but also among stakeholders within the same city. This MIM will also provide input to [MIM2 Data models](../architecture-and-data-models/oasc-mim-2-data-models.md), in particular regarding data which has an explicit geospatial dimension.
 
 ## Capabilities
 
@@ -79,14 +79,14 @@ The specifications that are subject to adoption are focussing on (i) web interfa
 * **API-based family of standards:**
 
 The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards) are built upon the legacy of the OGC Web Service standards to define resource-centric APIs that take advantage of modern web development practices. These new standards are web-friendly and are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(The following OGC APIs are at a different stage of development: Features, Common, Maps, Records, Processes, Coverages, Tiles, Environmental Data Retrieval\).
-  * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings) standard provides an open source and uniform API to connect IoT devices, data and applications on the Web; it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of OGC SOS and SPS.
-  * The [OGC API - Features](https://www.ogc.org/standards/ogcapi-features) standard xxxxxxxxx.
+  * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings) standard provides an open source and uniform API to connect IoT devices, data and applications on the Web; it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of OGC SOS and SPS. The SensorThings API standard supports both request-response and asynchronous transactions.
+  * The [OGC API - Features](https://www.ogc.org/standards/ogcapi-features) standard provides a modular, encoding-agnostic and web-friendly means for the exposure of geospatial features on the web.  
 
 \*\*\*\*
 
 ### Data encoding
 
-This section specifies data encodings for geospatial data that is also relevant for the provisions of [MIM2 Data models](https://github.com/alexanderkotsev/oasc-mims/blob/1.0.1/architecture-and-data-models/oasc-mim-2-data-models.md).
+This section specifies data encodings for geospatial data that is also relevant for the provisions of [MIM2 Data models](../architecture-and-data-models/oasc-mim-2-data-models.md).
 * **Semantic 3D city models or digital twins standards for representing the entities of cities and landscapes.**
   * [CityGML](https://www.ogc.org/standards/citygml), an OGC open data model and XML-based format for the storage and exchange of virtual 3D city models
   * [CityJSON](https://www.cityjson.org/), a community standard, JSON-based encoding for storing 3D city models, also called digital maquettes or digital twins.
@@ -96,7 +96,7 @@ This section specifies data encodings for geospatial data that is also relevant 
 
 ### Standards for implementing European Union's INSPIRE Directive
 
-For the European Union context, non-binding technical approaches are endorsed by the [INSPIRE](https://inspire.ec.europa.eu) Governance bodies. Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The following standards are available:
+For the European Union context, non-binding technical guidelines and good practices are endorsed by the [INSPIRE](https://inspire.ec.europa.eu) Governance bodies. Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The following standards are available:
 
 #### Network services
   * Discovery Services \(OGC CSW\)
@@ -104,6 +104,7 @@ For the European Union context, non-binding technical approaches are endorsed by
   * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds, [SensorThings API](https://github.com/INSPIRE-MIF/gp-ogc-sensorthings-api), [OGC API - Features](https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md)\)
 
 #### Data encoding
+  * [GML](https://github.com/INSPIRE-MIF/application-schemas)
   * [GeoJSON](https://github.com/INSPIRE-MIF/2017.2/blob/master/GeoJSON/geojson-encoding-rule.md)
   * [GeoPackage](https://github.com/INSPIRE-MIF/gp-geopackage-encodings)
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -45,11 +45,11 @@ description: 'OASC MIM7: Geospatial Information Management'
 
 ## Objectives <a id="MIM1:ContextInformationManagement-Goal"></a>
 
-Specifies how to share spatial (and spatio-temporal) data, make theme interoperable with, within, and between systems and territories. This goes from static data about assets such as street lights, buildings, and streets to spatio-temporal data from sensors. The purpose of this Minimal Interoperability Mechanism (MIM) is to make this data and the way it is shared interoperable across cities, but also among stakeholders within the city. This MIM will also provide input to [MIM2 Data models](), in particular regarding data whih has a geospatial dimension.
+Specifies how to share spatial (and spatio-temporal) data, make theme interoperable with, within, and between systems and territories. This goes from static data about assets such as street lights, buildings, and streets to spatio-temporal data from sensors. The purpose of this Minimal Interoperability Mechanism (MIM) is to make this data and the way it is shared interoperable across cities, but also among stakeholders within the city. This MIM will also provide input to [MIM2 Data models](), in particular regarding data which has an explicit geospatial dimension.
 
 ## Capabilities
 
-Geospatial information contains comprehensive bi-dimensional or tri-dimensional representation (NOTE: spatio-temporal we can consider four-dimensional) and localization about real-world entities defined in a structured way with formal definitions and provides functionalities to enable access to different data sources and analyse spatial information.
+Geospatial information contains comprehensive bi-dimensional or tri-dimensional representation and localization about real-world entities defined in a structured way with formal definitions and provides functionalities to enable access to different data sources and analyse spatial information.
 
 It is essential to include the geospatial data dimension into smart cities information systems for adding localization capabilities and improving its usage with spatial analysis capabilities.
 
@@ -62,35 +62,39 @@ Retrieving and editing of geospatial information, can be achieved using Open sta
 Integrating context information with geospatial information can be enabled by the context management API and geospatial management API through common data information models defined in the MIM2 Data Models.
 
 ## Specifications <a id="MIM3:EcosystemTransactionManagement-Recommendedspecifications"></a>
+The specifications that are subject to adoption are focussing on (i) web services for access to data, and (ii) data encoding formats. 
 
-**Baseline specifications proposed for adoption:**
+### Web services
 
-* **International geospatial specifications defined and adopted on a global level by Open Geospatial Consortium \(OGC\):**
+
+* **Specifications by the Open Geospatial Consortium \(OGC\):**
+  **SOAP-based  family of standards:**
   * Catalog Service for the Web \([CSW](https://www.ogc.org/standards/cat)\)
   * OGC Web Map Services \([WMS](https://www.ogc.org/standards/wms)\)
   * OGC Web Feature Services \([WFS](https://www.ogc.org/standards/wfs)\)
   * OGC Web Coverage Services \([WCS](https://www.ogc.org/standards/wcs)\)
   * OGC Sensor Observation Services \([SOS](https://www.ogc.org/standards/sos)\)
 
-
-
-* **Standards for implementing European Union's INSPIRE Directive:**
-  * Discovery Services \(OGC CSW\)
-  * View Services \(OGC WMS\)
-  * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds\)
-
-
-
-* **Endorse the new API based family of OGC standards:**
+* **API-based family of standards:**
   * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings), provides an open-source and uniform API to connect IoT devices, data and applications on the Web, it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of OGC SOS and SPS.
   * The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards), built upon the legacy of OGC Web Service standards, to define resource-centric APIs that take advantage of modern web development practices. These standards are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(OGC APIs: Features, Common, Maps, Records, Processes, Coverages, Tiles, Styles EDR\)
 
 \*\*\*\*
 
+### Data encoding
+This section specifies data encodings for geospatial data that is also relevant for the provisions of MIM2.
 * **Semantic 3D city models or digital twins standards for representing the entities of cities and landscapes.**
   * [CityGML](https://www.ogc.org/standards/citygml), an OGC open data model and XML-based format for the storage and exchange of virtual 3D city models
   * [CityJSON](https://www.cityjson.org/), a community standard, JSON-based encoding for storing 3D city models, also called digital maquettes or digital twins.
   *  [Industry Foundation Classes](https://technical.buildingsmart.org/standards/ifc) \([IFC](https://technical.buildingsmart.org/standards/ifc/ifc-formats/)\), a buildingSmart open, international standard \([ISO 16739-1:2018](https://www.iso.org/standard/70303.html)\), for a standardized, digital description of the built environment, including buildings and civil infrastructure.
+  *  [ISO Observations & Measurements](https://www.ogc.org/standards/om), provides a conceptual model for representing spatio-temporal observation data. Both JSON and XML-based implementations of the conceptual model are available. This data encoding is the default for the OGC Sensor Observation Service (xml-based), and the [Sensing profile](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html) of the OGC SensorThingsAPI.
+
+* **Standards for implementing European Union's INSPIRE Directive:**
+For the European Union context, the following non-binding technical approaches are endorsed.
+  * Discovery Services \(OGC CSW\)
+  * View Services \(OGC WMS, WMTS\)
+  * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds, SensorThingsAPI, OGC API-Features\)
+Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases.
 
 
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -34,7 +34,7 @@ description: 'OASC MIM7: Geospatial Information Management'
     <tr>
       <td style="text-align:center">&#x2705;</td>
       <td style="text-align:center"></td>
-      <td style="text-align:center"></td>
+      <td style="text-align:center">&#x2705;</td>
       <td style="text-align:center"></td>
       <td style="text-align:center"></td>
       <td style="text-align:center"></td>

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -62,14 +62,14 @@ Retrieving and editing of geospatial information, can be achieved using Open sta
 Integrating context information with geospatial information can be enabled by the context management API and geospatial management API through common data information models defined in the MIM2 Data Models.
 
 ## Specifications <a id="MIM3:EcosystemTransactionManagement-Recommendedspecifications"></a>
-The specifications that are subject to adoption are focussing on (i) web services for access to data, and (ii) data encoding formats. 
+The specifications that are subject to adoption are focussing on (i) web interfaces for access to data, and (ii) data encoding formats. 
 
-### Web services
+### Web interfaces
 
 
 * **Specifications by the Open Geospatial Consortium \(OGC\)**
 
-  **SOAP-based  family of standards:**
+  **SOAP-based family of standards:**
   * Catalog Service for the Web \([CSW](https://www.ogc.org/standards/cat)\)
   * OGC Web Map Services \([WMS](https://www.ogc.org/standards/wms)\)
   * OGC Web Feature Services \([WFS](https://www.ogc.org/standards/wfs)\)
@@ -77,8 +77,8 @@ The specifications that are subject to adoption are focussing on (i) web service
   * OGC Sensor Observation Services \([SOS](https://www.ogc.org/standards/sos)\)
 
 * **API-based family of standards:**
+  * The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards), built upon the legacy of the OGC Web Service standards, to define resource-centric APIs that take advantage of modern web development practices. These standards are web-friendly and are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(The following OGC APIs are at a different stage of development: Features, Common, Maps, Records, Processes, Coverages, Tiles, Environmental Data Retrieval\).
   * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings), provides an open-source and uniform API to connect IoT devices, data and applications on the Web, it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of OGC SOS and SPS.
-  * The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards), built upon the legacy of OGC Web Service standards, to define resource-centric APIs that take advantage of modern web development practices. These standards are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(OGC APIs: Features, Common, Maps, Records, Processes, Coverages, Tiles, Styles EDR\)
 
 \*\*\*\*
 
@@ -90,13 +90,17 @@ This section specifies data encodings for geospatial data that is also relevant 
   * [CityJSON](https://www.cityjson.org/), a community standard, JSON-based encoding for storing 3D city models, also called digital maquettes or digital twins.
   *  [Industry Foundation Classes](https://technical.buildingsmart.org/standards/ifc) \([IFC](https://technical.buildingsmart.org/standards/ifc/ifc-formats/)\), a buildingSmart open, international standard \([ISO 16739-1:2018](https://www.iso.org/standard/70303.html)\), for a standardized, digital description of the built environment, including buildings and civil infrastructure.
   *  [ISO Observations & Measurements](https://www.ogc.org/standards/om), provides a conceptual model for representing spatio-temporal observation data. Both JSON and XML-based implementations of the conceptual model are available. This data encoding is the default for the OGC Sensor Observation Service (xml-based), and the [Sensing profile](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html) of the OGC SensorThingsAPI.
+  *  [Geopackage](https://www.geopackage.org/) provides an open, compact and efficient format for sharing geospatial data. It is based on an SQLite database and is very well supported by both proprietary and open source software tools.
 
-* **Standards for implementing European Union's INSPIRE Directive:**
-For the European Union context, the following non-binding technical approaches are endorsed.
+### Standards for implementing European Union's INSPIRE Directive
+
+For the European Union context, non-binding technical approaches are endorsed by the INSPIRE Governance bodies. Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The following standards are available:
+
+#### Network services
   * Discovery Services \(OGC CSW\)
   * View Services \(OGC WMS, WMTS\)
   * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds, SensorThingsAPI, [OGC API-Features](https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md)\)
-Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases.
 
+#### Data encoding
 
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -76,7 +76,7 @@ The specifications that are subject to adoption are focussing on (i) web interfa
   * OGC Web Coverage Service \([WCS](https://www.ogc.org/standards/wcs)\)
   * OGC Sensor Observation Service \([SOS](https://www.ogc.org/standards/sos)\)
 
-* **API-based family of standards:**
+**API-based family of standards:**
 
 The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards) are built upon the legacy of the OGC Web Service standards to define resource-centric APIs that take advantage of modern web development practices. These new standards are web-friendly and are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(The following OGC APIs are at a different stage of development: Features, Common, Maps, Records, Processes, Coverages, Tiles, Environmental Data Retrieval\).
   * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings) standard provides an open source and uniform API to connect IoT devices, data and applications on the Web; it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of OGC SOS and SPS. The SensorThings API standard supports both request-response and asynchronous transactions.

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -49,9 +49,9 @@ Specifies how to share spatial (and spatio-temporal) data, make them interoperab
 
 ## Capabilities
 
-Geospatial information contains comprehensive bi-dimensional, tri-dimensional and (when time is also involved) four-dimensional representation and localization about real-world entities defined in a structured way with formal definitions and provides functionalities to enable access to different data sources and analyse spatial information.
+Geospatial information contains comprehensive bi-dimensional, tri-dimensional and (when time is also involved) four-dimensional representationof  real-world entities defined in a structured way. Different datasets can easily be combined based on location. In addition, powerful spatial analyses can be operformed that give important insights to different stakeholders in the city. It is therefore essential to include the geospatial data dimension into smart cities information systems. 
 
-It is essential to include the geospatial data dimension into smart cities information systems for adding localization capabilities and improving its usage with spatial analysis capabilities. The discovery, retrieval, visualisation, querying and editing of geospatial information, using location and historical criteria can be achieved through open standard formats, protocols and preferably through the use of standard-based API interfaces. Integrating context information with geospatial information can be enabled by the context management API and geospatial management API through common data information models defined in the [MIM2 Data Models]().
+The discovery, retrieval, visualisation, querying and editing of geospatial information based on location and historical criteria can be achieved through open standard formats, protocols and preferably through the use of standard-based API interfaces. Integrating context information with geospatial information can be enabled by the context management API and geospatial management API through common data information models defined in the [MIM2 Data models](../architecture-and-data-models/oasc-mim-2-data-models.md).
 
 ## Specifications <a id="MIM3:EcosystemTransactionManagement-Recommendedspecifications"></a>
 The specifications that are subject to adoption are focussing on (i) web interfaces for access to data, and (ii) data encoding formats. 
@@ -59,6 +59,8 @@ The specifications that are subject to adoption are focussing on (i) web interfa
 ### Web interfaces
 
 **Specifications by the Open Geospatial Consortium \(OGC\)**
+
+Those standards are mature, well-known by the geospatial community and supported by a wide number of client and server implementations.
 
   **SOAP-based family of standards:**
   * Catalog Service for the Web \([CSW](https://www.ogc.org/standards/cat)\)

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -67,7 +67,8 @@ The specifications that are subject to adoption are focussing on (i) web service
 ### Web services
 
 
-* **Specifications by the Open Geospatial Consortium \(OGC\):**
+* **Specifications by the Open Geospatial Consortium \(OGC\)**
+
   **SOAP-based  family of standards:**
   * Catalog Service for the Web \([CSW](https://www.ogc.org/standards/cat)\)
   * OGC Web Map Services \([WMS](https://www.ogc.org/standards/wms)\)
@@ -82,7 +83,8 @@ The specifications that are subject to adoption are focussing on (i) web service
 \*\*\*\*
 
 ### Data encoding
-This section specifies data encodings for geospatial data that is also relevant for the provisions of MIM2.
+
+This section specifies data encodings for geospatial data that is also relevant for the provisions of [MIM2]().
 * **Semantic 3D city models or digital twins standards for representing the entities of cities and landscapes.**
   * [CityGML](https://www.ogc.org/standards/citygml), an OGC open data model and XML-based format for the storage and exchange of virtual 3D city models
   * [CityJSON](https://www.cityjson.org/), a community standard, JSON-based encoding for storing 3D city models, also called digital maquettes or digital twins.
@@ -93,7 +95,7 @@ This section specifies data encodings for geospatial data that is also relevant 
 For the European Union context, the following non-binding technical approaches are endorsed.
   * Discovery Services \(OGC CSW\)
   * View Services \(OGC WMS, WMTS\)
-  * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds, SensorThingsAPI, OGC API-Features\)
+  * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds, SensorThingsAPI, [OGC API-Features](https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md)\)
 Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases.
 
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -49,34 +49,36 @@ Specifies how to share spatial (and spatio-temporal) data, make them interoperab
 
 ## Capabilities
 
-Geospatial information contains comprehensive bi-dimensional, tri-dimensional and (when time is also involved) four-dimensional representationof  real-world entities defined in a structured way. Different datasets can easily be combined based on location. In addition, powerful spatial analyses can be operformed that give important insights to different stakeholders in the city. It is therefore essential to include the geospatial data dimension into smart cities information systems. 
+Geospatial information contains comprehensive bi-dimensional, tri-dimensional and (when time is also involved) four-dimensional representationof  real-world entities defined in a structured way. Different datasets can easily be combined based on location. In addition, powerful spatial analyses and sophisticated visualisation can be performed that provide important insights to different stakeholders in the city. It is therefore essential to include the geospatial data dimension into smart city information systems. 
 
-The discovery, retrieval, visualisation, querying and editing of geospatial information based on location and historical criteria can be achieved through open standard formats, protocols and preferably through the use of standard-based API interfaces. Integrating context information with geospatial information can be enabled by the context management API and geospatial management API through common data information models defined in the [MIM2 Data models](../architecture-and-data-models/oasc-mim-2-data-models.md).
+The discovery, querying, retrieval, visualisation, and editing of geospatial information based on location and temporal criteria can be achieved through open standard formats, protocols and preferably through the use of standardised API interfaces. Integrating context information with geospatial information can be enabled by the context management API and geospatial management API through common data information models defined in the [MIM2 Data models](../architecture-and-data-models/oasc-mim-2-data-models.md).
 
 ## Specifications <a id="MIM3:EcosystemTransactionManagement-Recommendedspecifications"></a>
-The specifications that are subject to adoption are focussing on (i) web interfaces for access to data, and (ii) data encoding formats. 
+The specifications that are subject to adoption are focussing on (i) web interfaces for discovery and access to data, and (ii) data encoding formats. 
 
-### Web interfaces
+### Web Interfaces
 
 **Specifications by the Open Geospatial Consortium \(OGC\)**
 
-Those standards are mature, well-known by the geospatial community and supported by a wide number of client and server implementations.
+  **OWS-based family of standards:**
 
-  **SOAP-based family of standards:**
-  * Catalog Service for the Web \([CSW](https://www.ogc.org/standards/cat)\)
-  * OGC Web Map Service \([WMS](https://www.ogc.org/standards/wms)\)
-  * OGC Web Map Tile Service \([WMTS](https://www.ogc.org/standards/wmts)\)
-  * OGC Web Feature Service \([WFS](https://www.ogc.org/standards/wfs)\)
-  * OGC Web Coverage Service \([WCS](https://www.ogc.org/standards/wcs)\)
-  * OGC Sensor Observation Service \([SOS](https://www.ogc.org/standards/sos)\)
+Those [OGC Web Services]() standards follow the same conceptual model. They are mature, well-known by the geospatial community and supported by a wide number of client and server implementations.
+
+* Catalogue Service for the Web \([CSW](https://www.ogc.org/standards/cat)\)
+* OGC Web Map Service \([WMS](https://www.ogc.org/standards/wms)\)
+* OGC Web Map Tile Service \([WMTS](https://www.ogc.org/standards/wmts)\)
+* OGC Web Feature Service \([WFS](https://www.ogc.org/standards/wfs)\)
+* OGC Web Coverage Service \([WCS](https://www.ogc.org/standards/wcs)\)
+* OGC Sensor Observation Service \([SOS](https://www.ogc.org/standards/sos)\)
 
 **API-based family of standards:**
 
 The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards) are built upon the legacy of the OGC Web Service standards to define resource-centric APIs that take advantage of modern web development practices. These new standards are web-friendly and are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(The following OGC APIs are at a different stage of development: Features, Common, Maps, Records, Processes, Coverages, Tiles, Environmental Data Retrieval\).
-  * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings) standard provides an open source and uniform API to connect IoT devices, data and applications on the Web; it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of OGC SOS and SPS. The SensorThings API standard supports both request-response and asynchronous transactions.
+  * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings) standard provides an open source and uniform API to connect IoT devices, data and applications on the Web; it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of the OGC SOS and SPS. The SensorThings API standard supports both request-response and asynchronous transactions.
   * The [OGC API - Features](https://www.ogc.org/standards/ogcapi-features) standard provides a modular, encoding-agnostic and web-friendly means for the exposure of geospatial features on the web.  
 
 \*\*\*\*
+
 
 ### Data encoding
 
@@ -84,7 +86,7 @@ This section specifies data encodings for geospatial data that is also relevant 
 * Semantic 3D city models or digital twins standards for representing the entities of cities and landscapes.
   * [CityGML](https://www.ogc.org/standards/citygml), an OGC open data model and XML-based format for the storage and exchange of virtual 3D city models
   * [CityJSON](https://www.cityjson.org/), a community standard, JSON-based encoding for storing 3D city models, also called digital maquettes or digital twins.
-* [Industry Foundation Classes](https://technical.buildingsmart.org/standards/ifc) \([IFC](https://technical.buildingsmart.org/standards/ifc/ifc-formats/)\), a buildingSmart open, international standard \([ISO 16739-1:2018](https://www.iso.org/standard/70303.html)\), for a standardized, digital description of the built environment, including buildings and civil infrastructure.
+* [Industry Foundation Classes](https://technical.buildingsmart.org/standards/ifc) \([IFC](https://technical.buildingsmart.org/standards/ifc/ifc-formats/)\), a buildingSmart open, international standard \([ISO 16739-1:2018](https://www.iso.org/standard/70303.html)\), for a standardised, digital description of the built environment, including buildings and civil infrastructure.
 *  [ISO Observations & Measurements](https://www.ogc.org/standards/om), providing a conceptual model for representing spatio-temporal observation data. Both JSON and XML-based implementations of the conceptual model are available. This data encoding is the default for the OGC Sensor Observation Service (xml-based), and the [Sensing profile](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html) of the OGC SensorThings API.
 *  [GeoPackage](https://www.geopackage.org/) provides an open, compact and efficient format for sharing geospatial data. It is based on an SQLite database and is very well supported by both proprietary and open source software tools.
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -1,5 +1,5 @@
 ---
-description: 'OASC MIM7: Geospatial Information Management'
+description: 'OASC MIM7: Places'
 ---
 
 # MIM7 - Places

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -45,11 +45,11 @@ description: 'OASC MIM7: Places'
 
 ## Objectives <a id="MIM1:ContextInformationManagement-Goal"></a>
 
-Specifies how to share spatial (and spatio-temporal) data, make theme interoperable with, within, and between systems and territories. This goes from static data about assets such as street lights, buildings, and streets to spatio-temporal data from sensors. The purpose of this Minimal Interoperability Mechanism (MIM) is to make this data and the way it is shared interoperable across cities, but also among stakeholders within the city. This MIM will also provide input to [MIM2 Data models](), in particular regarding data which has an explicit geospatial dimension.
+Specifies how to share spatial (and spatio-temporal) data, make them interoperable with, within, and between systems and territories. This goes from static data about assets such as street lights, buildings, and streets to spatio-temporal data from sensors. The purpose of this Minimal Interoperability Mechanism (MIM) is to make this data and the way it is shared interoperable across cities, but also among stakeholders within the same city. This MIM will also provide input to [MIM2 Data models](https://github.com/alexanderkotsev/oasc-mims/blob/1.0.1/architecture-and-data-models/oasc-mim-2-data-models.md), in particular regarding data which has an explicit geospatial dimension.
 
 ## Capabilities
 
-Geospatial information contains comprehensive bi-dimensional or tri-dimensional representation and localization about real-world entities defined in a structured way with formal definitions and provides functionalities to enable access to different data sources and analyse spatial information.
+Geospatial information contains comprehensive bi-dimensional, tri-dimensional and (when time is also involved) four-dimensional representation and localization about real-world entities defined in a structured way with formal definitions and provides functionalities to enable access to different data sources and analyse spatial information.
 
 It is essential to include the geospatial data dimension into smart cities information systems for adding localization capabilities and improving its usage with spatial analysis capabilities.
 
@@ -66,46 +66,48 @@ The specifications that are subject to adoption are focussing on (i) web interfa
 
 ### Web interfaces
 
-
 * **Specifications by the Open Geospatial Consortium \(OGC\)**
 
   **SOAP-based family of standards:**
   * Catalog Service for the Web \([CSW](https://www.ogc.org/standards/cat)\)
-  * OGC Web Map Services \([WMS](https://www.ogc.org/standards/wms)\)
-  * OGC Web Feature Services \([WFS](https://www.ogc.org/standards/wfs)\)
-  * OGC Web Coverage Services \([WCS](https://www.ogc.org/standards/wcs)\)
-  * OGC Sensor Observation Services \([SOS](https://www.ogc.org/standards/sos)\)
+  * OGC Web Map Service \([WMS](https://www.ogc.org/standards/wms)\)
+  * OGC Web Map Tile Service \([WMTS](https://www.ogc.org/standards/wmts)\)
+  * OGC Web Feature Service \([WFS](https://www.ogc.org/standards/wfs)\)
+  * OGC Web Coverage Service \([WCS](https://www.ogc.org/standards/wcs)\)
+  * OGC Sensor Observation Service \([SOS](https://www.ogc.org/standards/sos)\)
 
 * **API-based family of standards:**
 
-The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards), built upon the legacy of the OGC Web Service standards, to define resource-centric APIs that take advantage of modern web development practices. These standards are web-friendly and are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(The following OGC APIs are at a different stage of development: Features, Common, Maps, Records, Processes, Coverages, Tiles, Environmental Data Retrieval\).
-  * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings), provides an open-source and uniform API to connect IoT devices, data and applications on the Web, it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of OGC SOS and SPS.
-  * The [OGC API-Features](https://www.ogc.org/standards/ogcapi-features) xxxxxxxxx.
+The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards) are built upon the legacy of the OGC Web Service standards to define resource-centric APIs that take advantage of modern web development practices. These new standards are web-friendly and are being constructed as "building blocks" that can be used to assemble novel APIs for web access to geospatial content. \(The following OGC APIs are at a different stage of development: Features, Common, Maps, Records, Processes, Coverages, Tiles, Environmental Data Retrieval\).
+  * The [OGC SensorThings API](https://www.ogc.org/standards/sensorthings) standard provides an open source and uniform API to connect IoT devices, data and applications on the Web; it provides a standard way to manage and retrieve observations and metadata from IoT sensors built on the legacy of OGC SOS and SPS.
+  * The [OGC API - Features](https://www.ogc.org/standards/ogcapi-features) standard xxxxxxxxx.
 
 \*\*\*\*
 
 ### Data encoding
 
-This section specifies data encodings for geospatial data that is also relevant for the provisions of [MIM2]().
+This section specifies data encodings for geospatial data that is also relevant for the provisions of [MIM2 Data models](https://github.com/alexanderkotsev/oasc-mims/blob/1.0.1/architecture-and-data-models/oasc-mim-2-data-models.md).
 * **Semantic 3D city models or digital twins standards for representing the entities of cities and landscapes.**
   * [CityGML](https://www.ogc.org/standards/citygml), an OGC open data model and XML-based format for the storage and exchange of virtual 3D city models
   * [CityJSON](https://www.cityjson.org/), a community standard, JSON-based encoding for storing 3D city models, also called digital maquettes or digital twins.
-  *  [Industry Foundation Classes](https://technical.buildingsmart.org/standards/ifc) \([IFC](https://technical.buildingsmart.org/standards/ifc/ifc-formats/)\), a buildingSmart open, international standard \([ISO 16739-1:2018](https://www.iso.org/standard/70303.html)\), for a standardized, digital description of the built environment, including buildings and civil infrastructure.
-  *  [ISO Observations & Measurements](https://www.ogc.org/standards/om), provides a conceptual model for representing spatio-temporal observation data. Both JSON and XML-based implementations of the conceptual model are available. This data encoding is the default for the OGC Sensor Observation Service (xml-based), and the [Sensing profile](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html) of the OGC SensorThingsAPI.
-  *  [Geopackage](https://www.geopackage.org/) provides an open, compact and efficient format for sharing geospatial data. It is based on an SQLite database and is very well supported by both proprietary and open source software tools.
+  * [Industry Foundation Classes](https://technical.buildingsmart.org/standards/ifc) \([IFC](https://technical.buildingsmart.org/standards/ifc/ifc-formats/)\), a buildingSmart open, international standard \([ISO 16739-1:2018](https://www.iso.org/standard/70303.html)\), for a standardized, digital description of the built environment, including buildings and civil infrastructure.
+  *  [ISO Observations & Measurements](https://www.ogc.org/standards/om), providing a conceptual model for representing spatio-temporal observation data. Both JSON and XML-based implementations of the conceptual model are available. This data encoding is the default for the OGC Sensor Observation Service (xml-based), and the [Sensing profile](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html) of the OGC SensorThings API.
+  *  [GeoPackage](https://www.geopackage.org/) provides an open, compact and efficient format for sharing geospatial data. It is based on an SQLite database and is very well supported by both proprietary and open source software tools.
 
 ### Standards for implementing European Union's INSPIRE Directive
 
-For the European Union context, non-binding technical approaches are endorsed by the INSPIRE Governance bodies. Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The following standards are available:
+For the European Union context, non-binding technical approaches are endorsed by the [INSPIRE](https://inspire.ec.europa.eu) Governance bodies. Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The following standards are available:
 
 #### Network services
   * Discovery Services \(OGC CSW\)
   * View Services \(OGC WMS, WMTS\)
-  * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds, SensorThingsAPI, [OGC API-Features](https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md)\)
+  * Download Services \(OGC WFS, WCS, SOS, ATOM Feeds, [SensorThings API](https://github.com/INSPIRE-MIF/gp-ogc-sensorthings-api), [OGC API - Features](https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md)\)
 
 #### Data encoding
+  * [GeoJSON](https://github.com/INSPIRE-MIF/2017.2/blob/master/GeoJSON/geojson-encoding-rule.md)
+  * [GeoPackage](https://github.com/INSPIRE-MIF/gp-geopackage-encodings)
 
 #### Validation
 
-An advantage of INSPIRE is the ability to validate metadata, services and data aginst the technical provisions listed above. To this end, an open source reference validator is being used.
+An advantage of INSPIRE is the ability to validate metadata, services and data aginst the technical provisions listed above. To this end, the [INSPIRE reference validator](https://inspire.ec.europa.eu/validator/), fully based on open source components, is being used.
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -62,14 +62,14 @@ The specifications that are subject to adoption are focussing on (i) web interfa
 
   **OWS-based family of standards:**
 
-Those [OGC Web Services]() standards follow the same conceptual model. They are mature, well-known by the geospatial community and supported by a wide number of client and server implementations.
+Those [OGC Web Services](https://www.ogc.org/standards/owc) standards follow the same conceptual model. They are mature, well-known by the geospatial community and supported by a wide number of client and server implementations.
 
 * Catalogue Service for the Web \([CSW](https://www.ogc.org/standards/cat)\)
-* OGC Web Map Service \([WMS](https://www.ogc.org/standards/wms)\)
-* OGC Web Map Tile Service \([WMTS](https://www.ogc.org/standards/wmts)\)
-* OGC Web Feature Service \([WFS](https://www.ogc.org/standards/wfs)\)
-* OGC Web Coverage Service \([WCS](https://www.ogc.org/standards/wcs)\)
-* OGC Sensor Observation Service \([SOS](https://www.ogc.org/standards/sos)\)
+* Web Map Service \([WMS](https://www.ogc.org/standards/wms)\)
+* Web Map Tile Service \([WMTS](https://www.ogc.org/standards/wmts)\)
+* Web Feature Service \([WFS](https://www.ogc.org/standards/wfs)\)
+* Web Coverage Service \([WCS](https://www.ogc.org/standards/wcs)\)
+* Sensor Observation Service \([SOS](https://www.ogc.org/standards/sos)\)
 
 **API-based family of standards:**
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -55,7 +55,7 @@ Geospatial information contains comprehensive bi-dimensional or tri-dimensional 
 
 It’s crucial to include the geospatial data dimension into smart cities information systems for adding localization capabilities and improving its usage with spatial analysis capabilities.
 
-Discovery and querying of geospatial information, using location and historical criteria can be achieved using Open standard formats, protocols and preferably Open API standard interfaces..
+Discovery and querying of geospatial information, using location and historical criteria can be achieved using Open standard formats, protocols and preferably Open API standard interfaces.
 
 Displaying and viewing of geospatial information, can be achieved using Open standard formats, protocols and preferably Open API standard interfaces.
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -49,7 +49,7 @@ Specifies how to share spatial (and spatio-temporal) data, make them interoperab
 
 ## Capabilities
 
-Geospatial information contains comprehensive bi-dimensional, tri-dimensional and (when time is also involved) four-dimensional representationof  real-world entities defined in a structured way. Different datasets can easily be combined based on location. In addition, powerful spatial analyses and sophisticated visualisation can be performed that provide important insights to different stakeholders in the city. It is therefore essential to include the geospatial data dimension into smart city information systems. 
+Geospatial information contains comprehensive bi-dimensional, tri-dimensional and (when time is also involved) four-dimensional representation of real-world entities defined in a structured way. Different datasets can easily be combined based on location. In addition, powerful spatial analyses and sophisticated visualisation can be performed that provide important insights to different stakeholders in the city. It is therefore essential to include the geospatial data dimension into smart city information systems. 
 
 The discovery, querying, retrieval, visualisation, and editing of geospatial information based on location and temporal criteria can be achieved through open standard formats, protocols and preferably through the use of standardised API interfaces. Integrating context information with geospatial information can be enabled by the context management API and geospatial management API through common data information models defined in the [MIM2 Data models](../architecture-and-data-models/oasc-mim-2-data-models.md).
 
@@ -92,7 +92,7 @@ This section specifies data encodings for geospatial data that is also relevant 
 
 ### Standards for implementing European Union's INSPIRE Directive
 
-For the European Union context, non-binding [technical guidelines]() and [good practices]() are available for implementing the legal provisions of the [INSPIRE Directive](https://inspire.ec.europa.eu). Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The governance of the technical specifications is ensured by the INSPIRE Maintenance and Implementation group (MIG), and its permanent technical sub-group (MIG-T). The following standards are available:
+For the European Union context, non-binding [technical guidelines](https://inspire.ec.europa.eu/Technical-Guidelines/Data-Specifications/2892) and [good practices](https://inspire.ec.europa.eu/portfolio/good-practice-library) are available for implementing the legal provisions of the [INSPIRE Directive](https://inspire.ec.europa.eu). Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The governance of the technical specifications is ensured by the INSPIRE Maintenance and Implementation group (MIG), and its permanent technical sub-group (MIG-T). The following standards are available:
 
 #### Network services
   * Discovery Services \(OGC CSW\)

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -45,15 +45,15 @@ description: 'OASC MIM7: Geospatial Information Management'
 
 ## Objectives <a id="MIM1:ContextInformationManagement-Goal"></a>
 
-Specifies how to handle geospatial data, make it interoperable with, within, and between systems and territories. This goes from streetlights, buildings, streets to complete cities and regions. The purpose of this MIM is to make this data interoperable across cities, but also to make this data interoperable with the other data captured by a city, like IoT data. 
+Specifies how to share spatial (and spatio-temporal) data, make theme interoperable with, within, and between systems and territories. This goes from static data about assets such as street lights, buildings, and streets to spatio-temporal data from sensors. The purpose of this Minimal Interoperability Mechanism (MIM) is to make this data and the way it is shared interoperable across cities, but also among stakeholders within the city. 
 
-This MIM will also provide input the MIM2 Data models, in the body of Geospatial Data Models.
+This MIM will also provide input to [MIM2 Data models](), in particular regarding data whih has a geospatial dimension.
 
 ## Capabilities
 
-Geospatial information contains comprehensive bi-dimensional or tri-dimensional representation and localization about real-world entities defined in a structured way with formal definitions and provides functionalities to enable access to different data sources and analyse spatial information.
+Geospatial information contains comprehensive bi-dimensional or tri-dimensional representation (NOTE: spatio-temporal we can consider four-dimensional) and localization about real-world entities defined in a structured way with formal definitions and provides functionalities to enable access to different data sources and analyse spatial information.
 
-It’s crucial to include the geospatial data dimension into smart cities information systems for adding localization capabilities and improving its usage with spatial analysis capabilities.
+It is essential to include the geospatial data dimension into smart cities information systems for adding localization capabilities and improving its usage with spatial analysis capabilities.
 
 Discovery and querying of geospatial information, using location and historical criteria can be achieved using Open standard formats, protocols and preferably Open API standard interfaces.
 

--- a/interaction/oasc-mim7-places.md
+++ b/interaction/oasc-mim7-places.md
@@ -51,22 +51,14 @@ Specifies how to share spatial (and spatio-temporal) data, make them interoperab
 
 Geospatial information contains comprehensive bi-dimensional, tri-dimensional and (when time is also involved) four-dimensional representation and localization about real-world entities defined in a structured way with formal definitions and provides functionalities to enable access to different data sources and analyse spatial information.
 
-It is essential to include the geospatial data dimension into smart cities information systems for adding localization capabilities and improving its usage with spatial analysis capabilities.
-
-Discovery and querying of geospatial information, using location and historical criteria can be achieved using Open standard formats, protocols and preferably Open API standard interfaces.
-
-Displaying and viewing of geospatial information, can be achieved using Open standard formats, protocols and preferably Open API standard interfaces.
-
-Retrieving and editing of geospatial information, can be achieved using Open standard formats, protocols and preferably Open API standard interfaces.
-
-Integrating context information with geospatial information can be enabled by the context management API and geospatial management API through common data information models defined in the MIM2 Data Models.
+It is essential to include the geospatial data dimension into smart cities information systems for adding localization capabilities and improving its usage with spatial analysis capabilities. The discovery, retrieval, visualisation, querying and editing of geospatial information, using location and historical criteria can be achieved through open standard formats, protocols and preferably through the use of standard-based API interfaces. Integrating context information with geospatial information can be enabled by the context management API and geospatial management API through common data information models defined in the [MIM2 Data Models]().
 
 ## Specifications <a id="MIM3:EcosystemTransactionManagement-Recommendedspecifications"></a>
 The specifications that are subject to adoption are focussing on (i) web interfaces for access to data, and (ii) data encoding formats. 
 
 ### Web interfaces
 
-* **Specifications by the Open Geospatial Consortium \(OGC\)**
+**Specifications by the Open Geospatial Consortium \(OGC\)**
 
   **SOAP-based family of standards:**
   * Catalog Service for the Web \([CSW](https://www.ogc.org/standards/cat)\)
@@ -87,16 +79,16 @@ The new [OGC Web API family of standards](https://ogcapi.ogc.org/#standards) are
 ### Data encoding
 
 This section specifies data encodings for geospatial data that is also relevant for the provisions of [MIM2 Data models](../architecture-and-data-models/oasc-mim-2-data-models.md).
-* **Semantic 3D city models or digital twins standards for representing the entities of cities and landscapes.**
+* Semantic 3D city models or digital twins standards for representing the entities of cities and landscapes.
   * [CityGML](https://www.ogc.org/standards/citygml), an OGC open data model and XML-based format for the storage and exchange of virtual 3D city models
   * [CityJSON](https://www.cityjson.org/), a community standard, JSON-based encoding for storing 3D city models, also called digital maquettes or digital twins.
-  * [Industry Foundation Classes](https://technical.buildingsmart.org/standards/ifc) \([IFC](https://technical.buildingsmart.org/standards/ifc/ifc-formats/)\), a buildingSmart open, international standard \([ISO 16739-1:2018](https://www.iso.org/standard/70303.html)\), for a standardized, digital description of the built environment, including buildings and civil infrastructure.
-  *  [ISO Observations & Measurements](https://www.ogc.org/standards/om), providing a conceptual model for representing spatio-temporal observation data. Both JSON and XML-based implementations of the conceptual model are available. This data encoding is the default for the OGC Sensor Observation Service (xml-based), and the [Sensing profile](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html) of the OGC SensorThings API.
-  *  [GeoPackage](https://www.geopackage.org/) provides an open, compact and efficient format for sharing geospatial data. It is based on an SQLite database and is very well supported by both proprietary and open source software tools.
+* [Industry Foundation Classes](https://technical.buildingsmart.org/standards/ifc) \([IFC](https://technical.buildingsmart.org/standards/ifc/ifc-formats/)\), a buildingSmart open, international standard \([ISO 16739-1:2018](https://www.iso.org/standard/70303.html)\), for a standardized, digital description of the built environment, including buildings and civil infrastructure.
+*  [ISO Observations & Measurements](https://www.ogc.org/standards/om), providing a conceptual model for representing spatio-temporal observation data. Both JSON and XML-based implementations of the conceptual model are available. This data encoding is the default for the OGC Sensor Observation Service (xml-based), and the [Sensing profile](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html) of the OGC SensorThings API.
+*  [GeoPackage](https://www.geopackage.org/) provides an open, compact and efficient format for sharing geospatial data. It is based on an SQLite database and is very well supported by both proprietary and open source software tools.
 
 ### Standards for implementing European Union's INSPIRE Directive
 
-For the European Union context, non-binding technical guidelines and good practices are endorsed by the [INSPIRE](https://inspire.ec.europa.eu) Governance bodies. Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The following standards are available:
+For the European Union context, non-binding [technical guidelines]() and [good practices]() are available for implementing the legal provisions of the [INSPIRE Directive](https://inspire.ec.europa.eu). Technical specifications are made available for each standard, which enable data providers to choose a particular solution based on the specific needs and concrete use cases. The governance of the technical specifications is ensured by the INSPIRE Maintenance and Implementation group (MIG), and its permanent technical sub-group (MIG-T). The following standards are available:
 
 #### Network services
   * Discovery Services \(OGC CSW\)


### PR DESCRIPTION
- Update to MIM-7
  - improve the context description and capabilities overview, 
  - organise the standards into (i) standards for discovery and access, and (ii) standards for data encoding;
  - add O&M and Geopackage, and update to SensorThingsAPI;
- Add INSPIRE, relevant for EU cities within the context of the MIM plus initiative;
- Cross-reference of MIM2 and MIM7 for encoding of geospatial data;
- Add reference to the ISA2 Core Location Vocabulary.


TODO: 
 - Consider adding VectorTiles and binary encodings
- Clarify where OpenAPI/swagger can fit (e.g. in another MIM document).