### PR TITLE
Removing the last (draft) presentation

### DIFF
--- a/integrity/oasc-mim4-trust/references.md
+++ b/integrity/oasc-mim4-trust/references.md
@@ -40,12 +40,3 @@ Presenters: Raf Buyle, Ruben Verborgh
 Orgs: Information Flanders, Ghent University / IMEC
 {% endhint %}
 
-### Paper : "From MyData Declaration to Proactive and Human-Centric Services" \(2020\)
-
-{% file src="../../.gitbook/assets/spaces\_-muhjrpmvzaivjur7wsr\_pdf\_3590797559.pdf" caption="Helsinki MyData Declaration to Proactive and Human-Centric Services" %}
-
-{% hint style="info" %}
-Authors: Mikko Rusama, Mika Huhtamäki  
-Orgs: City of Helsinki, Vastuu Group
-{% endhint %}
-


### PR DESCRIPTION
The first/lowermost document on the page is preferably not to be shared yet (authors Mikko Rusama and Mika Huhtamäki have a more mature/updated paper in works). Thus, remove this for now, please.